### PR TITLE
fix RowTable title links

### DIFF
--- a/RowTables.tid
+++ b/RowTables.tid
@@ -73,7 +73,7 @@ tags: $:/tags/Macro
         variable=unused
         emptyMessage=<<ThisTiddler>>
       >
-        <$link>
+        <$link to=<<ThisTiddler>>>
           <<ThisTiddler>>
         </$link>
       </$list>


### PR DESCRIPTION
Fixes bug where the title of a row would be linked to the current tiddler (i.e., the tiddler containing the RowTable), rather than the tiddler represented by that row.